### PR TITLE
Exponer TeamPagePreview

### DIFF
--- a/src/cms/preview-templates/TeamPagePreview.js
+++ b/src/cms/preview-templates/TeamPagePreview.js
@@ -16,3 +16,5 @@ const TeamPagePreview = ({ entry, getAsset }) => {
     />
   )
 }
+
+export default TeamPagePreview


### PR DESCRIPTION
Gracias a #44 se encontro que `TeamPagePreview` no estaba siendo usado, agregue un `export default` para que el cms encuentre el componente.